### PR TITLE
Overwrite packages during consolidation step

### DIFF
--- a/BonsaiInterface/Assets/Bonsai/BonsaiInstallerEditor.cs
+++ b/BonsaiInterface/Assets/Bonsai/BonsaiInstallerEditor.cs
@@ -92,15 +92,8 @@ public class BonsaiInstallerEditor : Editor
         foreach (string fromFile in allQueries)
         {
             string toFile = $"{rootPath}/Assets/Packages/{Path.GetFileName(fromFile)}";
-            if (!File.Exists(toFile))
-            {
-                UnityEngine.Debug.Log($"Copying {fromFile} to {toFile}");
-                File.Copy(fromFile, toFile);
-            }
-            else
-            {
-                UnityEngine.Debug.LogWarning($"File {toFile} already exists. Skipping file copy.");
-            }
+            UnityEngine.Debug.Log($"Copying {fromFile} to {toFile}");
+            File.Copy(fromFile, toFile, true);
         }
 
         EditorUtility.DisplayDialog("Bonsai", "Package consolidation complete. See debug console for details.", "OK");

--- a/BonsaiInterface/Assets/Bonsai/BonsaiInstallerEditor.cs
+++ b/BonsaiInterface/Assets/Bonsai/BonsaiInstallerEditor.cs
@@ -24,7 +24,7 @@ public class BonsaiInstallerEditor : Editor
         if (!File.Exists(rootPath + "/Bonsai.zip"))
         {
             WebClient client = new WebClient();
-            client.DownloadFile("https://github.com/bonsai-rx/bonsai/releases/download/2.6.3/Bonsai.zip", rootPath + "/Bonsai.zip");
+            client.DownloadFile("https://github.com/bonsai-rx/bonsai/releases/download/2.7/Bonsai.zip", rootPath + "/Bonsai.zip");
         }
         else
         {

--- a/BonsaiInterface/Assets/Bonsai/BonsaiWorkflow.cs
+++ b/BonsaiInterface/Assets/Bonsai/BonsaiWorkflow.cs
@@ -14,6 +14,7 @@ using Bonsai.Dag;
 public class BonsaiWorkflow : MonoBehaviour
 {
     public BonsaiWorkflowAsset BonsaiWorkflowAsset;
+    public bool AutoStart = false;
 
     private WorkflowBuilder WorkflowBuilder;
     private IObservable<System.Reactive.Unit> WorkflowRuntime;
@@ -32,7 +33,10 @@ public class BonsaiWorkflow : MonoBehaviour
 
     private void Start()
     {
-        StartWorkflow();
+        if (AutoStart)
+        {
+            StartWorkflow();
+        }
     }
 
     private void StartWorkflow()


### PR DESCRIPTION
This pull request addresses issue #4. Previously, during the package consolidation step, the BonsaiWorkflowEditor script would only copy *new* packages from the Bonsai environment, i.e. those with a name that was not present in the Unity packages. This meant that updates to existing Bonsai packages from the editor would be ignored in the Unity packages. The safer option is just to overwrite all packages so that the Unity packages are guaranteed to match those in the Bonsai installation.

- Fixes #4 
- Upgrades the default Bonsai installation to 2.7
- Adds an auto-start toggle to the BonsaiWorkflow class so that users can choose to initiate the workflow after the Unity scene has started, or keep the original behaviour of starting with the scene.